### PR TITLE
Exclude jsp-api

### DIFF
--- a/spring-cloud-starter-stream-sink-task-launcher-yarn/pom.xml
+++ b/spring-cloud-starter-stream-sink-task-launcher-yarn/pom.xml
@@ -32,6 +32,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-deployer-yarn</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet.jsp</groupId>
+					<artifactId>jsp-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- Causing javax.el.ExpressionFactory to get pulled
  in from hadoop deps using old/stale version while
  new and properer is expected from tomcat-embed-el.
- Fixes #3